### PR TITLE
*: online update count in table stats. (#3053)

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -131,6 +131,7 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 	} else {
 		sc.AddAffectedRows(2)
 	}
+	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.Meta().ID, 0, 1)
 	return nil
 }
 
@@ -252,6 +253,7 @@ func (e *DeleteExec) removeRow(ctx context.Context, t table.Table, h int64, data
 	}
 	getDirtyDB(ctx).deleteRow(t.Meta().ID, h)
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
+	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.Meta().ID, -1, 1)
 	return nil
 }
 

--- a/session.go
+++ b/session.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/sessionctx/varsutil"
+	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
@@ -127,6 +128,8 @@ type session struct {
 
 	sessionVars    *variable.SessionVars
 	sessionManager util.SessionManager
+
+	statsCollector *statistics.SessionStatsCollector
 }
 
 // Cancel cancels the execution of current transaction.
@@ -271,6 +274,12 @@ func (s *session) doCommitWithRetry() error {
 	if err != nil {
 		log.Warnf("[%d] finished txn:%v, %v", s.sessionVars.ConnectionID, s.txn, err)
 		return errors.Trace(err)
+	}
+	mapper := s.GetSessionVars().TxnCtx.TableDeltaMap
+	if s.statsCollector != nil && mapper != nil {
+		for id, item := range mapper {
+			s.statsCollector.Update(id, item.Delta, item.Count)
+		}
 	}
 	return nil
 }
@@ -742,6 +751,9 @@ func (s *session) ClearValue(key fmt.Stringer) {
 
 // Close function does some clean work when session end.
 func (s *session) Close() error {
+	if s.statsCollector != nil {
+		s.statsCollector.Delete()
+	}
 	return s.RollbackTxn()
 }
 
@@ -830,6 +842,11 @@ func CreateSession(store kv.Storage) (Session, error) {
 		Handle: do.PrivilegeHandle(),
 	}
 	privilege.BindPrivilegeManager(s, pm)
+
+	// Add statsUpdateHandle.
+	if do.StatsHandle() != nil {
+		s.statsCollector = do.StatsHandle().NewSessionStatsCollector()
+	}
 
 	return s, nil
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -81,6 +81,18 @@ type TransactionContext struct {
 	InfoSchema    interface{}
 	Histroy       interface{}
 	SchemaVersion int64
+	TableDeltaMap map[int64]TableDelta
+}
+
+// UpdateDeltaForTable updates the delta info for some table.
+func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, count int64) {
+	if tc.TableDeltaMap == nil {
+		tc.TableDeltaMap = make(map[int64]TableDelta)
+	}
+	item := tc.TableDeltaMap[tableID]
+	item.Delta += delta
+	item.Count += count
+	tc.TableDeltaMap[tableID] = item
 }
 
 // SessionVars is to handle user-defined or global variables in current session.
@@ -272,6 +284,12 @@ const (
 	MaxAllowedPacket    = "max_allowed_packet"
 	TimeZone            = "time_zone"
 )
+
+// TableDelta stands for the changed count for one table.
+type TableDelta struct {
+	Delta int64
+	Count int64
+}
 
 // StatementContext contains variables for a statement.
 // It should be reset before executing a statement.

--- a/statistics/statscache.go
+++ b/statistics/statscache.go
@@ -35,6 +35,11 @@ type Handle struct {
 	statsCache  atomic.Value
 	// ddlEventCh is a channel to notify a ddl operation has happened. It is sent only by owner and read by stats handle.
 	ddlEventCh chan *ddl.Event
+
+	// All the stats collector required by session are maintained in this list.
+	listHead *SessionStatsCollector
+	// We collect the delta map and merge them with globalMap.
+	globalMap tableDeltaMap
 }
 
 // Clear the statsCache, only for test.
@@ -48,6 +53,8 @@ func NewHandle(ctx context.Context) *Handle {
 	handle := &Handle{
 		ctx:        ctx,
 		ddlEventCh: make(chan *ddl.Event, 100),
+		listHead:   &SessionStatsCollector{mapper: make(tableDeltaMap)},
+		globalMap:  make(tableDeltaMap),
 	}
 	handle.statsCache.Store(statsCache{})
 	return handle

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -1,0 +1,130 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/log"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/util/sqlexec"
+)
+
+type tableDeltaMap map[int64]variable.TableDelta
+
+func (m tableDeltaMap) update(id int64, delta int64, count int64) {
+	item := m[id]
+	item.Delta += delta
+	item.Count += count
+	m[id] = item
+}
+
+func (m tableDeltaMap) merge(handle *SessionStatsCollector) {
+	handle.Lock()
+	defer handle.Unlock()
+	for id, item := range handle.mapper {
+		m.update(id, item.Delta, item.Count)
+	}
+	handle.mapper = make(tableDeltaMap)
+}
+
+// SessionStatsCollector is a list item that holds the delta mapper. If you want to write or read mapper, you must lock it.
+type SessionStatsCollector struct {
+	sync.Mutex
+
+	mapper tableDeltaMap
+	prev   *SessionStatsCollector
+	next   *SessionStatsCollector
+	// If a session is closed, it only sets this flag true. Every time we sweep the list, we will remove the useless collector.
+	deleted bool
+}
+
+// Delete only sets the deleted flag true, it will be deleted from list when DumpStatsDeltaToKV is called.
+func (s *SessionStatsCollector) Delete() {
+	s.Lock()
+	defer s.Unlock()
+	s.deleted = true
+}
+
+// Update will updates the delta and count for one table id.
+func (s *SessionStatsCollector) Update(id int64, delta int64, count int64) {
+	s.Lock()
+	defer s.Unlock()
+	s.mapper.update(id, delta, count)
+}
+
+// tryToRemoveFromList will remove this collector from the list if it's deleted flag is set.
+func (s *SessionStatsCollector) tryToRemoveFromList() {
+	s.Lock()
+	defer s.Unlock()
+	if !s.deleted {
+		return
+	}
+	next := s.next
+	prev := s.prev
+	prev.next = next
+	if next != nil {
+		next.prev = prev
+	}
+}
+
+// NewSessionStatsCollector allocates a stats collector for a session.
+func (h *Handle) NewSessionStatsCollector() *SessionStatsCollector {
+	h.listHead.Lock()
+	defer h.listHead.Unlock()
+	newCollector := &SessionStatsCollector{
+		mapper: make(tableDeltaMap),
+		next:   h.listHead.next,
+		prev:   h.listHead,
+	}
+	if h.listHead.next != nil {
+		h.listHead.next.prev = newCollector
+	}
+	h.listHead.next = newCollector
+	return newCollector
+}
+
+// DumpStatsDeltaToKV sweeps the whole list and updates the global map. Then we dumps every table that held in map to KV.
+func (h *Handle) DumpStatsDeltaToKV() {
+	h.listHead.Lock()
+	for collector := h.listHead.next; collector != nil; collector = collector.next {
+		collector.tryToRemoveFromList()
+		h.globalMap.merge(collector)
+	}
+	h.listHead.Unlock()
+	for id, item := range h.globalMap {
+		err := h.dumpTableStatDeltaToKV(id, item)
+		if err == nil {
+			delete(h.globalMap, id)
+		} else {
+			log.Warnf("Error happens when updating stats table, the error message is %s.", err.Error())
+		}
+	}
+}
+
+// dumpTableStatDeltaToKV dumps a single delta with some table to KV and updates the version.
+func (h *Handle) dumpTableStatDeltaToKV(id int64, delta variable.TableDelta) error {
+	_, err := h.ctx.(sqlexec.SQLExecutor).Execute("begin")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = h.ctx.(sqlexec.SQLExecutor).Execute(fmt.Sprintf("update mysql.stats_meta set version = %d, count = count + %d, modify_count = modify_count + %d where table_id = %d", h.ctx.Txn().StartTS(), delta.Delta, delta.Count, id))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = h.ctx.(sqlexec.SQLExecutor).Execute("commit")
+	return errors.Trace(err)
+}

--- a/statistics/update_list_test.go
+++ b/statistics/update_list_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testUpdateListSuite{})
+
+type testUpdateListSuite struct {
+}
+
+func (s *testUpdateListSuite) TestInsertAndDelete(c *C) {
+	h := NewHandle(nil)
+	var items []*SessionStatsCollector
+	for i := 0; i < 5; i++ {
+		items = append(items, h.NewSessionStatsCollector())
+	}
+	items[0].Delete() // delete tail
+	items[2].Delete() // delete middle
+	items[4].Delete() // delete head
+	h.DumpStatsDeltaToKV()
+
+	c.Assert(h.listHead.next, Equals, items[3])
+	c.Assert(items[3].next, Equals, items[1])
+	c.Assert(items[1].next, IsNil)
+	c.Assert(items[1].prev, Equals, items[3])
+	c.Assert(items[3].prev, Equals, h.listHead)
+
+	// delete rest
+	items[1].Delete()
+	items[3].Delete()
+	h.DumpStatsDeltaToKV()
+	c.Assert(h.listHead.next, IsNil)
+}

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -1,0 +1,211 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+var _ = Suite(&testStatsUpdateSuite{})
+
+type testStatsUpdateSuite struct{}
+
+func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
+	store, do, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer store.Close()
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t1 (c1 int, c2 int)")
+	testKit.MustExec("create table t2 (c1 int, c2 int)")
+
+	rowCount1 := 10
+	rowCount2 := 20
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	for i := 0; i < rowCount2; i++ {
+		testKit.MustExec("insert into t2 values(1, 2)")
+	}
+
+	is := do.InfoSchema()
+	tbl1, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	c.Assert(err, IsNil)
+	tableInfo1 := tbl1.Meta()
+	h := do.StatsHandle()
+
+	h.HandleDDLEvent(<-h.DDLEventCh())
+	h.HandleDDLEvent(<-h.DDLEventCh())
+
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 := h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1))
+
+	tbl2, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
+	c.Assert(err, IsNil)
+	tableInfo2 := tbl2.Meta()
+	stats2 := h.GetTableStats(tableInfo2)
+	c.Assert(stats2.Count, Equals, int64(rowCount2))
+
+	// Test update in a txn.
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 = h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1*2))
+
+	testKit.MustExec("begin")
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	testKit.MustExec("commit")
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 = h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1*3))
+
+	testKit.MustExec("begin")
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("delete from t1 limit 1")
+	}
+	for i := 0; i < rowCount2; i++ {
+		testKit.MustExec("update t2 set c2 = c1")
+	}
+	testKit.MustExec("commit")
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 = h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1*3))
+	stats2 = h.GetTableStats(tableInfo2)
+	c.Assert(stats2.Count, Equals, int64(rowCount2))
+
+	rs := testKit.MustQuery("select modify_count from mysql.stats_meta")
+	rs.Check(testkit.Rows("50", "40"))
+}
+
+func (s *testStatsUpdateSuite) TestMultiSession(c *C) {
+	store, do, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer store.Close()
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t1 (c1 int, c2 int)")
+
+	rowCount1 := 10
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+
+	testKit1 := testkit.NewTestKit(c, store)
+	for i := 0; i < rowCount1; i++ {
+		testKit1.MustExec("insert into test.t1 values(1, 2)")
+	}
+	testKit2 := testkit.NewTestKit(c, store)
+	for i := 0; i < rowCount1; i++ {
+		testKit2.MustExec("delete from test.t1 limit 1")
+	}
+	is := do.InfoSchema()
+	tbl1, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	c.Assert(err, IsNil)
+	tableInfo1 := tbl1.Meta()
+	h := do.StatsHandle()
+
+	h.HandleDDLEvent(<-h.DDLEventCh())
+
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 := h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1))
+
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+
+	for i := 0; i < rowCount1; i++ {
+		testKit1.MustExec("insert into test.t1 values(1, 2)")
+	}
+
+	for i := 0; i < rowCount1; i++ {
+		testKit2.MustExec("delete from test.t1 limit 1")
+	}
+
+	err = testKit.Se.Close()
+	c.Assert(err, IsNil)
+
+	err = testKit2.Se.Close()
+	c.Assert(err, IsNil)
+
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 = h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1*2))
+	rs := testKit.MustQuery("select modify_count from mysql.stats_meta")
+	rs.Check(testkit.Rows("60"))
+}
+
+func (s *testStatsUpdateSuite) TestTxnWithFailure(c *C) {
+	store, do, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer store.Close()
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t1 (c1 int primary key, c2 int)")
+
+	is := do.InfoSchema()
+	tbl1, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	c.Assert(err, IsNil)
+	tableInfo1 := tbl1.Meta()
+	h := do.StatsHandle()
+
+	h.HandleDDLEvent(<-h.DDLEventCh())
+
+	rowCount1 := 10
+	testKit.MustExec("begin")
+	for i := 0; i < rowCount1; i++ {
+		testKit.MustExec("insert into t1 values(?, 2)", i)
+	}
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 := h.GetTableStats(tableInfo1)
+	// have not commit
+	c.Assert(stats1.Count, Equals, int64(0))
+	testKit.MustExec("commit")
+
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 = h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1))
+
+	_, err = testKit.Exec("insert into t1 values(0, 2)")
+	c.Assert(err, NotNil)
+
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 = h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1))
+
+	testKit.MustExec("insert into t1 values(-1, 2)")
+	h.DumpStatsDeltaToKV()
+	h.Update(is)
+	stats1 = h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1+1))
+}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -355,6 +355,7 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 		mutation.Sequence = append(mutation.Sequence, binlog.MutationType_Insert)
 	}
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
+	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.ID, 1, 1)
 	return recordID, nil
 }
 


### PR DESCRIPTION
When insert and update happens, we will cache the changed info in every session. After a duration(five minutes now) passes, handle will sweep every cache and merge them. Then dump the delta info to TiKV.